### PR TITLE
fix: 選択状態での誤入力によるテキスト破壊を完全防止（issue #4）

### DIFF
--- a/convert-romaji-clipboard.swift
+++ b/convert-romaji-clipboard.swift
@@ -52,6 +52,17 @@ func writeDebugLog(_ message: String) {
     }
 }
 
+// Karabiner変数を設定する（karabiner_cliを使用）
+func setKarabinerVariable(_ name: String, value: Int) {
+    let task = Process()
+    task.executableURL = URL(fileURLWithPath: "/Library/Application Support/org.pqrs/Karabiner-Elements/bin/karabiner_cli")
+    task.arguments = ["--set-variables", "{\"\(name)\": \(value)}"]
+    task.standardOutput = FileHandle.nullDevice
+    task.standardError = FileHandle.nullDevice
+    try? task.run()
+    task.waitUntilExit()
+}
+
 // キーストロークを送信する関数
 func sendKeyPress(_ keyCode: CGKeyCode, withModifiers modifiers: CGEventFlags = []) {
     let source = CGEventSource(stateID: .hidSystemState)
@@ -182,6 +193,7 @@ func selectAndCopyWord() -> String? {
     writeDebugLog("Cmd+C でコピー")
     sendKeyPress(kVK_ANSI_C, withModifiers: .maskCommand)
     sendKeyPress(0x7C) // Right arrow - 選択解除（コピー直後）
+    setKarabinerVariable("ime_converting", value: 0) // キーブロック解除（選択解除直後）
     usleep(50000) // 50ms待機（クリップボード書き込み完了を待つ）
     writeDebugLog("⏱ クリップボードコピー＋選択解除完了: \(elapsedMs())")
 
@@ -249,6 +261,7 @@ func main() {
     if !trusted {
         writeDebugLog("❌ Accessibility権限がありません")
         print("Accessibility権限が必要です")
+        setKarabinerVariable("ime_converting", value: 0) // 安全のため解除
         closeDebugLog()
         exit(1)
     }
@@ -257,6 +270,7 @@ func main() {
     // 単語を選択してコピー
     guard let selectedText = selectAndCopyWord() else {
         writeDebugLog("⚠️ テキスト選択失敗 -> 通常のIMEオンのみ")
+        setKarabinerVariable("ime_converting", value: 0) // 安全のため解除
         sendKeyPress(kVK_JIS_Kana)
         closeDebugLog()
         exit(0)
@@ -268,6 +282,7 @@ func main() {
     // 選択されたテキストの末尾からローマ字を抽出
     guard let result = extractRomajiFromEnd(selectedText) else {
         writeDebugLog("⚠️ 末尾にローマ字なし: \(selectedText) -> 通常のIMEオンのみ")
+        setKarabinerVariable("ime_converting", value: 0) // 安全のため解除
         sendKeyPress(kVK_JIS_Kana)
         closeDebugLog()
         exit(0)

--- a/modeless-ime.json
+++ b/modeless-ime.json
@@ -7,6 +7,23 @@
         {
           "type": "basic",
           "from": {
+            "any": "key_code",
+            "modifiers": {
+              "optional": ["any"]
+            }
+          },
+          "to": [],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "ime_converting",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
             "key_code": "j",
             "modifiers": {
               "mandatory": ["control"],
@@ -20,6 +37,12 @@
             {
               "set_variable": {
                 "name": "ime_active",
+                "value": 1
+              }
+            },
+            {
+              "set_variable": {
+                "name": "ime_converting",
                 "value": 1
               }
             }


### PR DESCRIPTION
## Summary

- Karabiner-Elementsのキーブロック機能を使い、ctrl-j押下中の物理キー入力を完全にブロック
- Cmd+Shift+Left による選択状態の時間を約460ms→約70msに短縮

## 変更内容

### modeless-ime.json
- ctrl-j の `to` に `ime_converting=1` をセット追加（ctrl-j押下と同時にブロック開始）
- `ime_converting=1` の間、全 `key_code` を飲み込むルールを先頭に追加

### convert-romaji-clipboard.swift
- `setKarabinerVariable()` 関数を追加（`karabiner_cli` 経由でKarabiner変数を操作）
- Cmd+C直後にRight arrowを送信して選択解除を早め（460ms→70ms）
- Right arrow送信直後に `ime_converting=0` をセットしてブロック解除
- 全 `exit()` パスに `ime_converting=0` のクリーンアップを追加

## ブロックの仕組み

```
ctrl-j 押下
  → ime_converting=1（即座に全キーブロック） ← Karabinerが同期的に処理
  → スクリプト起動（非同期）
      Cmd+Shift+Left ← 物理キー入力がブロックされている
      Cmd+C
      Right arrow（選択解除）
      ime_converting=0（ブロック解除）← 約70ms後
      deleteFast, IME, ローマ字送信...
```

## Test plan

- [x] nihongo を入力して ctrl-j -> 日本語 に正しく変換されることを確認
- [x] ctrl-j 直後にキーを連打しても文字列が壊れないことを確認
- [x] Enter/Escape で正常に変換確定・キャンセルできることを確認

Closes #4

Generated with Claude Code