### PR TITLE
refactor: タイミング定数化・関数統合（issue #7）

### DIFF
--- a/convert-romaji-clipboard.swift
+++ b/convert-romaji-clipboard.swift
@@ -10,6 +10,23 @@ let kVK_ANSI_C: CGKeyCode = 0x08
 let kVK_LeftArrow: CGKeyCode = 0x7B
 let kVK_Space: CGKeyCode = 0x31
 
+// タイミング定数（マイクロ秒）
+let WAIT_KEY_PRESS_US:       UInt32 = 5000   // sendKey デフォルト: キー送信間隔 (5ms)
+let WAIT_ROMAJI_CHAR_US:     UInt32 = 0      // ローマ字1文字送信間隔 (0ms - CGEventは待機不要)
+let WAIT_DELETE_CHAR_US:     UInt32 = 0      // Backspace1文字間隔 (0ms - CGEventは待機不要)
+let WAIT_CLIPBOARD_CLEAR_US: UInt32 = 20000  // クリップボードクリア後の待機 (20ms)
+let WAIT_WORD_SELECT_US:     UInt32 = 50000  // Cmd+Shift+Left後の待機 (50ms)
+let WAIT_CLIPBOARD_COPY_US:  UInt32 = 50000  // Cmd+C後の待機 (50ms)
+let WAIT_DELETE_AFTER_US:    UInt32 = 20000  // deleteFast後の待機 (20ms)
+let WAIT_IME_STARTUP_US:     UInt32 = 80000  // IME起動待機 (80ms) ※80ms未満は不安定
+let WAIT_PRE_CONVERT_US:     UInt32 = 20000  // Space送信前の待機 (20ms)
+
+// パス定数
+let KARABINER_CLI_PATH = "/Library/Application Support/org.pqrs/Karabiner-Elements/bin/karabiner_cli"
+
+// Karabiner変数名定数
+let VAR_IME_CONVERTING = "ime_converting"
+
 // 計測用: スクリプト開始時刻
 var scriptStartTime = Date()
 
@@ -55,7 +72,7 @@ func writeDebugLog(_ message: String) {
 // Karabiner変数を設定する（karabiner_cliを使用）
 func setKarabinerVariable(_ name: String, value: Int) {
     let task = Process()
-    task.executableURL = URL(fileURLWithPath: "/Library/Application Support/org.pqrs/Karabiner-Elements/bin/karabiner_cli")
+    task.executableURL = URL(fileURLWithPath: KARABINER_CLI_PATH)
     task.arguments = ["--set-variables", "{\"\(name)\": \(value)}"]
     task.standardOutput = FileHandle.nullDevice
     task.standardError = FileHandle.nullDevice
@@ -63,8 +80,8 @@ func setKarabinerVariable(_ name: String, value: Int) {
     task.waitUntilExit()
 }
 
-// キーストロークを送信する関数
-func sendKeyPress(_ keyCode: CGKeyCode, withModifiers modifiers: CGEventFlags = []) {
+// キーストロークを送信する関数（waitUs でキー間隔を指定）
+func sendKey(_ keyCode: CGKeyCode, withModifiers modifiers: CGEventFlags = [], waitUs: UInt32 = WAIT_KEY_PRESS_US) {
     let source = CGEventSource(stateID: .hidSystemState)
     let keyDown = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: true)
     let keyUp = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: false)
@@ -73,24 +90,9 @@ func sendKeyPress(_ keyCode: CGKeyCode, withModifiers modifiers: CGEventFlags = 
     keyUp?.flags = modifiers
 
     keyDown?.post(tap: .cghidEventTap)
-    usleep(5000) // 5ms待機（互換性重視の最適化）
+    usleep(waitUs)
     keyUp?.post(tap: .cghidEventTap)
-    usleep(5000)
-}
-
-// ローマ字入力専用の高速キー送信（deleteFastと同じ間隔で高速化）
-func sendRomajiChar(_ keyCode: CGKeyCode, withModifiers modifiers: CGEventFlags = []) {
-    let source = CGEventSource(stateID: .hidSystemState)
-    let keyDown = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: true)
-    let keyUp = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: false)
-
-    keyDown?.flags = modifiers
-    keyUp?.flags = modifiers
-
-    keyDown?.post(tap: .cghidEventTap)
-    usleep(0) // 0ms（CGEventオーバーヘッド計測用）
-    keyUp?.post(tap: .cghidEventTap)
-    usleep(0) // 0ms（CGEventオーバーヘッド計測用）
+    usleep(waitUs)
 }
 
 // 高速Backspace用の関数（ユーザー入力との競合を防ぐため選択方式から変更）
@@ -102,9 +104,9 @@ func deleteFast(_ count: Int) {
         let keyUp = CGEvent(keyboardEventSource: source, virtualKey: kVK_Delete, keyDown: false)
 
         keyDown?.post(tap: .cghidEventTap)
-        usleep(0) // 0ms（CGEventオーバーヘッド計測用）
+        usleep(WAIT_DELETE_CHAR_US)
         keyUp?.post(tap: .cghidEventTap)
-        usleep(0) // 0ms（CGEventオーバーヘッド計測用）
+        usleep(WAIT_DELETE_CHAR_US)
     }
 }
 
@@ -179,22 +181,22 @@ func selectAndCopyWord() -> String? {
 
     // クリップボードをクリア（空文字列を設定）
     setClipboardString("")
-    usleep(20000) // 20ms待機
+    usleep(WAIT_CLIPBOARD_CLEAR_US)
     writeDebugLog("⏱ クリップボードクリア完了: \(elapsedMs())")
 
     // Cmd+Shift+Left で単語を選択
     writeDebugLog("Cmd+Shift+Left で単語選択")
-    sendKeyPress(kVK_LeftArrow, withModifiers: [.maskCommand, .maskShift])
-    usleep(50000) // 50ms待機
+    sendKey(kVK_LeftArrow, withModifiers: [.maskCommand, .maskShift])
+    usleep(WAIT_WORD_SELECT_US)
     writeDebugLog("⏱ 単語選択完了: \(elapsedMs())")
 
     // Cmd+C でコピー → 直後に Right arrow で選択解除（選択状態を最小化）
     // CGEventはキューに積まれるため、Cmd+CのコピーはRight arrow処理前に完了する
     writeDebugLog("Cmd+C でコピー")
-    sendKeyPress(kVK_ANSI_C, withModifiers: .maskCommand)
-    sendKeyPress(0x7C) // Right arrow - 選択解除（コピー直後）
-    setKarabinerVariable("ime_converting", value: 0) // キーブロック解除（選択解除直後）
-    usleep(50000) // 50ms待機（クリップボード書き込み完了を待つ）
+    sendKey(kVK_ANSI_C, withModifiers: .maskCommand)
+    sendKey(0x7C) // Right arrow - 選択解除（コピー直後）
+    setKarabinerVariable(VAR_IME_CONVERTING, value: 0) // キーブロック解除（選択解除直後）
+    usleep(WAIT_CLIPBOARD_COPY_US)
     writeDebugLog("⏱ クリップボードコピー＋選択解除完了: \(elapsedMs())")
 
     // クリップボードから取得
@@ -261,7 +263,7 @@ func main() {
     if !trusted {
         writeDebugLog("❌ Accessibility権限がありません")
         print("Accessibility権限が必要です")
-        setKarabinerVariable("ime_converting", value: 0) // 安全のため解除
+        setKarabinerVariable(VAR_IME_CONVERTING, value: 0) // 安全のため解除
         closeDebugLog()
         exit(1)
     }
@@ -270,8 +272,8 @@ func main() {
     // 単語を選択してコピー
     guard let selectedText = selectAndCopyWord() else {
         writeDebugLog("⚠️ テキスト選択失敗 -> 通常のIMEオンのみ")
-        setKarabinerVariable("ime_converting", value: 0) // 安全のため解除
-        sendKeyPress(kVK_JIS_Kana)
+        setKarabinerVariable(VAR_IME_CONVERTING, value: 0) // 安全のため解除
+        sendKey(kVK_JIS_Kana)
         closeDebugLog()
         exit(0)
     }
@@ -282,8 +284,8 @@ func main() {
     // 選択されたテキストの末尾からローマ字を抽出
     guard let result = extractRomajiFromEnd(selectedText) else {
         writeDebugLog("⚠️ 末尾にローマ字なし: \(selectedText) -> 通常のIMEオンのみ")
-        setKarabinerVariable("ime_converting", value: 0) // 安全のため解除
-        sendKeyPress(kVK_JIS_Kana)
+        setKarabinerVariable(VAR_IME_CONVERTING, value: 0) // 安全のため解除
+        sendKey(kVK_JIS_Kana)
         closeDebugLog()
         exit(0)
     }
@@ -296,24 +298,24 @@ func main() {
     // deleteCount の文字数分を高速Backspaceで削除（選択状態を作らないため安全）
     writeDebugLog("🔙 Backspaceで\(deleteCount)文字を削除（高速モード）")
     deleteFast(deleteCount)
-    usleep(20000) // 20ms待機
+    usleep(WAIT_DELETE_AFTER_US)
     writeDebugLog("⏱ 削除完了: \(elapsedMs())")
 
     // IMEをオン
     writeDebugLog("🈴 IMEをオン")
-    sendKeyPress(kVK_JIS_Kana)
-    usleep(80000) // 80ms待機（IME起動を待つ）
+    sendKey(kVK_JIS_Kana)
+    usleep(WAIT_IME_STARTUP_US)
     writeDebugLog("⏱ IME起動完了: \(elapsedMs())")
 
-    // ローマ字を1文字ずつ高速送信（sendRomajiChar: 3ms/文字）
+    // ローマ字を1文字ずつ高速送信（waitUs: WAIT_ROMAJI_CHAR_US = 0ms）
     writeDebugLog("⌨️  ローマ字を再送信: \(romaji) (\(romaji.count)文字)")
     for char in romaji {
         if let keyCode = getKeyCode(for: char) {
             // Shiftキーが必要な文字の場合
             if needsShift(char) {
-                sendRomajiChar(keyCode, withModifiers: .maskShift)
+                sendKey(keyCode, withModifiers: .maskShift, waitUs: WAIT_ROMAJI_CHAR_US)
             } else {
-                sendRomajiChar(keyCode)
+                sendKey(keyCode, waitUs: WAIT_ROMAJI_CHAR_US)
             }
         } else {
             writeDebugLog("  ⚠️ キーコード未定義: \(char)")
@@ -322,8 +324,8 @@ func main() {
     writeDebugLog("⏱ ローマ字送信完了: \(elapsedMs())")
 
     // スペースキーを送信して変換
-    usleep(20000) // 20ms待機（ローマ字入力完了を待つ）
-    sendKeyPress(kVK_Space)
+    usleep(WAIT_PRE_CONVERT_US)
+    sendKey(kVK_Space)
     writeDebugLog("␣ 変換完了")
     writeDebugLog("⏱ 総経過時間: \(elapsedMs())")
 


### PR DESCRIPTION
## Summary

- タイミング調整値をリテラルから名前付き定数に変更
- sendKeyPress / sendRomajiChar を sendKey(waitUs:) に統合
- "ime_converting" 文字列を定数化

## 変更内容

### 定数化した値

| 定数名 | 値 | 用途 |
|--------|-----|------|
| WAIT_KEY_PRESS_US | 5000 | sendKey デフォルト間隔 (5ms) |
| WAIT_ROMAJI_CHAR_US | 0 | ローマ字1文字送信間隔 (0ms) |
| WAIT_DELETE_CHAR_US | 0 | Backspace1文字間隔 (0ms) |
| WAIT_CLIPBOARD_CLEAR_US | 20000 | クリップボードクリア後 (20ms) |
| WAIT_WORD_SELECT_US | 50000 | Cmd+Shift+Left後 (50ms) |
| WAIT_CLIPBOARD_COPY_US | 50000 | Cmd+C後 (50ms) |
| WAIT_DELETE_AFTER_US | 20000 | deleteFast後 (20ms) |
| WAIT_IME_STARTUP_US | 80000 | IME起動待機 (80ms) |
| WAIT_PRE_CONVERT_US | 20000 | Space送信前 (20ms) |
| KARABINER_CLI_PATH | パス文字列 | karabiner_cli のパス |
| VAR_IME_CONVERTING | "ime_converting" | Karabiner変数名 |

### 関数統合

```swift
// 変更前: 2つの重複関数
func sendKeyPress(_ keyCode: CGKeyCode, withModifiers modifiers: CGEventFlags = []) { ... }
func sendRomajiChar(_ keyCode: CGKeyCode, withModifiers modifiers: CGEventFlags = []) { ... }

// 変更後: waitUs パラメータで統一
func sendKey(_ keyCode: CGKeyCode, withModifiers modifiers: CGEventFlags = [], waitUs: UInt32 = WAIT_KEY_PRESS_US) { ... }
```

## Test plan

- [ ] nihongo を入力して ctrl-j -> 日本語 に正しく変換されることを確認
- [ ] 動作が変更前と同じであることを確認（リファクタリングのみ）

Closes #7

Generated with Claude Code